### PR TITLE
Add corner radius based on content view's corner radius.

### DIFF
--- a/ShimmerBlocks/Classes/ShimmerContainerView.swift
+++ b/ShimmerBlocks/Classes/ShimmerContainerView.swift
@@ -104,6 +104,8 @@ private extension ShimmerContainer {
             sectionSubviews.forEach { stackView.addArrangedSubview($0) }
             containerView = stackView
         }
+        containerView.layer.cornerRadius = data.view?.layer.cornerRadius ?? 0
+        containerView.clipsToBounds = true
         return containerView
     }
 


### PR DESCRIPTION
Forking from the 3rd party library we are using for the skeleton loading.
The shimmer block's corner radius is now set to the same as the content's corner radius, so that it is possible to control corner radius from outside.